### PR TITLE
Added GoLang VS Code Dark+ style support

### DIFF
--- a/resources/visual_studio_code_dark_plus.xml
+++ b/resources/visual_studio_code_dark_plus.xml
@@ -1,9 +1,9 @@
-<scheme name="Visual Studio Code Dark Plus" version="142" parent_scheme="Darcula">
+<scheme name="Visual Studio Code Dark Plus" version="143" parent_scheme="Darcula">
   <metaInfo>
-    <property name="created">2019-07-05T16:51:16</property>
-    <property name="ide">Idea</property>
-    <property name="ideVersion">2019.1.2.0.0</property>
-    <property name="modified">2019-07-05T16:51:20</property>
+    <property name="created">2020-02-05T15:57:56</property>
+    <property name="ide">GoLand</property>
+    <property name="ideVersion">2019.3.2.0.0</property>
+    <property name="modified">2020-02-05T15:58:12</property>
     <property name="originalScheme">Visual Studio Code Dark Plus</property>
   </metaInfo>
   <colors>
@@ -11,30 +11,28 @@
     <option name="CARET_ROW_COLOR" value="262626" />
     <option name="GUTTER_BACKGROUND" value="1d1d1d" />
     <option name="INDENT_GUIDE" value="3b3b3b" />
+    <option name="LINE_NUMBERS_COLOR" value="848484" />
     <option name="RIGHT_MARGIN_COLOR" value="3b3b3b" />
     <option name="SELECTION_BACKGROUND" value="264e77" />
-    <option name="LINE_NUMBERS_COLOR" value="848484" />
+    <option name="ScrollBar.Mac.hoverThumbBorderColor" value="4e4e4e" />
+    <option name="ScrollBar.Mac.hoverThumbColor" value="4e4e4e" />
+    <option name="ScrollBar.Mac.hoverTrackColor" value="1d1d1d" />
+    <option name="ScrollBar.Mac.thumbBorderColor" value="414141" />
+    <option name="ScrollBar.Mac.thumbColor" value="414141" />
+    <option name="ScrollBar.Mac.trackColor" value="1d1d1d" />
+    <option name="ScrollBar.Transparent.hoverThumbBorderColor" value="4e4e4e" />
+    <option name="ScrollBar.Transparent.hoverThumbColor" value="4e4e4e" />
+    <option name="ScrollBar.Transparent.hoverTrackColor" value="1d1d1d" />
+    <option name="ScrollBar.Transparent.thumbBorderColor" value="414141" />
+    <option name="ScrollBar.Transparent.thumbColor" value="414141" />
+    <option name="ScrollBar.Transparent.trackColor" value="1d1d1d" />
     <option name="VISUAL_INDENT_GUIDE" value="3b3b3b" />
-
-    <option name="ScrollBar.Mac.trackColor" value="1d1d1d"/>
-    <option name="ScrollBar.Mac.thumbColor" value="414141"/>
-    <option name="ScrollBar.Mac.thumbBorderColor" value="414141"/>
-    <option name="ScrollBar.Mac.hoverTrackColor" value="1d1d1d"/>
-    <option name="ScrollBar.Mac.hoverThumbColor" value="4e4e4e"/>
-    <option name="ScrollBar.Mac.hoverThumbBorderColor" value="4e4e4e"/>
-
-    <option name="ScrollBar.Transparent.trackColor" value="1d1d1d"/>
-    <option name="ScrollBar.Transparent.thumbColor" value="414141"/>
-    <option name="ScrollBar.Transparent.thumbBorderColor" value="414141"/>
-    <option name="ScrollBar.Transparent.hoverTrackColor" value="1d1d1d"/>
-    <option name="ScrollBar.Transparent.hoverThumbColor" value="4e4e4e"/>
-    <option name="ScrollBar.Transparent.hoverThumbBorderColor" value="4e4e4e"/>
   </colors>
   <attributes>
     <option name="ANNOTATION_ATTRIBUTE_NAME_ATTRIBUTES">
       <value />
     </option>
-    <option name="ANNOTATION_NAME_ATTRIBUTES" baseAttributes="DEFAULT_METADATA" />
+    <option name="ANNOTATION_NAME_ATTRIBUTES" baseAttributes="" />
     <option name="BAD_CHARACTER">
       <value>
         <option name="EFFECT_COLOR" value="f44747" />
@@ -51,7 +49,6 @@
         <option name="FOREGROUND" value="dcdcaa" />
       </value>
     </option>
-    <option name="BASH.HERE_DOC" baseAttributes="DEFAULT_STRING" />
     <option name="BASH.HERE_DOC_END">
       <value>
         <option name="FOREGROUND" value="c586c0" />
@@ -62,7 +59,6 @@
         <option name="FOREGROUND" value="c586c0" />
       </value>
     </option>
-    <option name="BASH.SHEBANG" baseAttributes="BASH.LINE_COMMENT" />
     <option name="BASH.VAR_DEF">
       <value>
         <option name="FOREGROUND" value="d3d3c8" />
@@ -161,7 +157,7 @@
     </option>
     <option name="DEFAULT_CONSTANT">
       <value>
-        <option name="FOREGROUND" value="d3d3d3" />
+        <option name="FOREGROUND" value="569cd6" />
       </value>
     </option>
     <option name="DEFAULT_DOC_COMMENT">
@@ -268,6 +264,192 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
+    <option name="GO_BLOCK_COMMENT">
+      <value>
+        <option name="FOREGROUND" value="6a9955" />
+      </value>
+    </option>
+    <option name="GO_BUILTIN_CONSTANT">
+      <value>
+        <option name="FOREGROUND" value="569cd6" />
+      </value>
+    </option>
+    <option name="GO_BUILTIN_FUNCTION">
+      <value>
+        <option name="FOREGROUND" value="dcdcaa" />
+      </value>
+    </option>
+    <option name="GO_BUILTIN_FUNCTION_CALL">
+      <value>
+        <option name="FOREGROUND" value="dcdcaa" />
+      </value>
+    </option>
+    <option name="GO_BUILTIN_TYPE_REFERENCE">
+      <value>
+        <option name="FOREGROUND" value="4ec9b0" />
+      </value>
+    </option>
+    <option name="GO_BUILTIN_VARIABLE">
+      <value>
+        <option name="FOREGROUND" value="569cd6" />
+      </value>
+    </option>
+    <option name="GO_COMMENT_KEYWORD">
+      <value>
+        <option name="FOREGROUND" value="6a9955" />
+        <option name="EFFECT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="GO_EXPORTED_FUNCTION">
+      <value>
+        <option name="FOREGROUND" value="dcdcaa" />
+      </value>
+    </option>
+    <option name="GO_EXPORTED_FUNCTION_CALL">
+      <value>
+        <option name="FOREGROUND" value="dcdcaa" />
+      </value>
+    </option>
+    <option name="GO_EXPORTED_INTERFACE_REFERENCE">
+      <value>
+        <option name="FOREGROUND" value="d4d4d4" />
+      </value>
+    </option>
+    <option name="GO_EXPORTED_STRUCT_REFERENCE">
+      <value>
+        <option name="FOREGROUND" value="d4d4d4" />
+      </value>
+    </option>
+    <option name="GO_FUNCTION_PARAMETER">
+      <value>
+        <option name="FOREGROUND" value="c8c8c8" />
+      </value>
+    </option>
+    <option name="GO_KEYWORD">
+      <value>
+        <option name="FOREGROUND" value="c586c0" />
+      </value>
+    </option>
+    <option name="GO_LABEL">
+      <value>
+        <option name="FOREGROUND" value="c8c8c8" />
+      </value>
+    </option>
+    <option name="GO_LINE_COMMENT">
+      <value>
+        <option name="FOREGROUND" value="6a9955" />
+      </value>
+    </option>
+    <option name="GO_LOCAL_CONSTANT">
+      <value>
+        <option name="FOREGROUND" value="c8c8c8" />
+      </value>
+    </option>
+    <option name="GO_LOCAL_FUNCTION">
+      <value>
+        <option name="FOREGROUND" value="dcdcaa" />
+      </value>
+    </option>
+    <option name="GO_LOCAL_FUNCTION_CALL">
+      <value>
+        <option name="FOREGROUND" value="dcdcaa" />
+      </value>
+    </option>
+    <option name="GO_LOCAL_INTERFACE_REFERENCE">
+      <value>
+        <option name="FOREGROUND" value="d4d4d4" />
+      </value>
+    </option>
+    <option name="GO_LOCAL_STRUCT_REFERENCE">
+      <value>
+        <option name="FOREGROUND" value="d4d4d4" />
+      </value>
+    </option>
+    <option name="GO_LOCAL_VARIABLE">
+      <value>
+        <option name="FOREGROUND" value="d4d4d4" />
+      </value>
+    </option>
+    <option name="GO_METHOD_RECEIVER">
+      <value>
+        <option name="FOREGROUND" value="c8c8c8" />
+      </value>
+    </option>
+    <option name="GO_PACKAGE">
+      <value>
+        <option name="FOREGROUND" value="d4d4d4" />
+      </value>
+    </option>
+    <option name="GO_PACKAGE_EXPORTED_CONSTANT">
+      <value>
+        <option name="FOREGROUND" value="9cdcfe" />
+      </value>
+    </option>
+    <option name="GO_PACKAGE_EXPORTED_INTERFACE">
+      <value>
+        <option name="FOREGROUND" value="d4d4d4" />
+      </value>
+    </option>
+    <option name="GO_PACKAGE_EXPORTED_STRUCT">
+      <value>
+        <option name="FOREGROUND" value="d4d4d4" />
+      </value>
+    </option>
+    <option name="GO_PACKAGE_EXPORTED_VARIABLE">
+      <value>
+        <option name="FOREGROUND" value="d4d4d4" />
+      </value>
+    </option>
+    <option name="GO_PACKAGE_LOCAL_CONSTANT">
+      <value>
+        <option name="FOREGROUND" value="9cdcfe" />
+      </value>
+    </option>
+    <option name="GO_PACKAGE_LOCAL_INTERFACE">
+      <value>
+        <option name="FOREGROUND" value="d4d4d4" />
+      </value>
+    </option>
+    <option name="GO_PACKAGE_LOCAL_STRUCT">
+      <value>
+        <option name="FOREGROUND" value="4ec9b0" />
+      </value>
+    </option>
+    <option name="GO_PACKAGE_LOCAL_VARIABLE">
+      <value>
+        <option name="FOREGROUND" value="d4d4d4" />
+      </value>
+    </option>
+    <option name="GO_SCOPE_VARIABLE">
+      <value>
+        <option name="FOREGROUND" value="d4d4d4" />
+      </value>
+    </option>
+    <option name="GO_STRUCT_EXPORTED_MEMBER">
+      <value>
+        <option name="FOREGROUND" value="d4d4d4" />
+      </value>
+    </option>
+    <option name="GO_STRUCT_LOCAL_MEMBER">
+      <value>
+        <option name="FOREGROUND" value="d4d4d4" />
+      </value>
+    </option>
+    <option name="GO_TYPE_REFERENCE">
+      <value>
+        <option name="FOREGROUND" value="d4d4d4" />
+      </value>
+    </option>
+    <option name="GO_TYPE_SPECIFICATION">
+      <value>
+        <option name="FOREGROUND" value="d4d4d4" />
+      </value>
+    </option>
+    <option name="GO_VALID_STRING_ESCAPE">
+      <value>
+        <option name="FOREGROUND" value="d7ba7d" />
+      </value>
+    </option>
     <option name="HTML_ATTRIBUTE_NAME">
       <value>
         <option name="FOREGROUND" value="9cdcfe" />
@@ -310,13 +492,12 @@
     <option name="INJECTED_LANGUAGE_FRAGMENT">
       <value />
     </option>
-    <option name="JAVA_KEYWORD" baseAttributes="DEFAULT_KEYWORD" />
+    <option name="JAVA_KEYWORD" baseAttributes="" />
     <option name="JS.PARAMETER">
       <value>
         <option name="FOREGROUND" value="9cdcfe" />
       </value>
     </option>
-    <option name="KOTLIN_ANNOTATION" baseAttributes="ANNOTATION_NAME_ATTRIBUTES" />
     <option name="KOTLIN_BACKING_FIELD_VARIABLE">
       <value />
     </option>
@@ -337,8 +518,6 @@
     <option name="KOTLIN_OBJECT">
       <value />
     </option>
-    <option name="KOTLIN_PACKAGE_FUNCTION_CALL" baseAttributes="DEFAULT_STATIC_METHOD" />
-    <option name="KOTLIN_TYPE_PARAMETER" baseAttributes="TYPE_PARAMETER_NAME_ATTRIBUTES" />
     <option name="MARKDOWN_AUTO_LINK">
       <value>
         <option name="EFFECT_COLOR" value="d4d4d4" />
@@ -458,7 +637,6 @@
     <option name="PHP_ALIAS_REFERENCE">
       <value />
     </option>
-    <option name="PHP_CONSTANT" baseAttributes="DEFAULT_CONSTANT" />
     <option name="PHP_EXEC_COMMAND_ID">
       <value>
         <option name="FOREGROUND" value="cd905b" />
@@ -479,10 +657,10 @@
         <option name="FOREGROUND" value="94dbfd" />
       </value>
     </option>
-    <option name="PROPERTIES.INVALID_STRING_ESCAPE" baseAttributes="DEFAULT_INVALID_STRING_ESCAPE" />
-    <option name="PROPERTIES.KEY" baseAttributes="DEFAULT_KEYWORD" />
-    <option name="PROPERTIES.KEY_VALUE_SEPARATOR" baseAttributes="DEFAULT_OPERATION_SIGN" />
-    <option name="PROPERTIES.VALID_STRING_ESCAPE" baseAttributes="DEFAULT_VALID_STRING_ESCAPE" />
+    <option name="PROPERTIES.INVALID_STRING_ESCAPE" baseAttributes="" />
+    <option name="PROPERTIES.KEY" baseAttributes="" />
+    <option name="PROPERTIES.KEY_VALUE_SEPARATOR" baseAttributes="" />
+    <option name="PROPERTIES.VALID_STRING_ESCAPE" baseAttributes="" />
     <option name="REGEXP.CHAR_CLASS">
       <value>
         <option name="FOREGROUND" value="d16969" />
@@ -522,8 +700,7 @@
     <option name="STATIC_METHOD_ATTRIBUTES">
       <value />
     </option>
-    <option name="Static method access" baseAttributes="STATIC_METHOD_ATTRIBUTES" />
-    <option name="Static property reference ID" baseAttributes="STATIC_FINAL_FIELD_ATTRIBUTES" />
+    <option name="Static method access" baseAttributes="" />
     <option name="TEXT">
       <value>
         <option name="FOREGROUND" value="d4d4d4" />
@@ -576,7 +753,7 @@
     <option name="XPATH.BRACKET">
       <value />
     </option>
-    <option name="XPATH.KEYWORD" baseAttributes="DEFAULT_KEYWORD" />
-    <option name="XPATH.XPATH_VARIABLE" baseAttributes="DEFAULT_LOCAL_VARIABLE" />
+    <option name="XPATH.KEYWORD" baseAttributes="" />
+    <option name="XPATH.XPATH_VARIABLE" baseAttributes="" />
   </attributes>
 </scheme>

--- a/resources/visual_studio_code_dark_plus.xml
+++ b/resources/visual_studio_code_dark_plus.xml
@@ -14,6 +14,7 @@
     <option name="RIGHT_MARGIN_COLOR" value="3b3b3b" />
     <option name="SELECTION_BACKGROUND" value="264e77" />
     <option name="LINE_NUMBERS_COLOR" value="848484" />
+    <option name="VISUAL_INDENT_GUIDE" value="3b3b3b" />
     
     <option name="ScrollBar.Mac.trackColor" value="1d1d1d" />
     <option name="ScrollBar.Mac.thumbColor" value="414141" />
@@ -28,8 +29,6 @@
     <option name="ScrollBar.Transparent.hoverTrackColor" value="1d1d1d" />
     <option name="ScrollBar.Transparent.hoverThumbColor" value="4e4e4e" />
     <option name="ScrollBar.Transparent.hoverThumbBorderColor" value="4e4e4e" />
-    
-    <option name="VISUAL_INDENT_GUIDE" value="3b3b3b" />
   </colors>
   <attributes>
     <option name="ANNOTATION_ATTRIBUTE_NAME_ATTRIBUTES">

--- a/resources/visual_studio_code_dark_plus.xml
+++ b/resources/visual_studio_code_dark_plus.xml
@@ -15,20 +15,20 @@
     <option name="SELECTION_BACKGROUND" value="264e77" />
     <option name="LINE_NUMBERS_COLOR" value="848484" />
     <option name="VISUAL_INDENT_GUIDE" value="3b3b3b" />
-    
-    <option name="ScrollBar.Mac.trackColor" value="1d1d1d" />
-    <option name="ScrollBar.Mac.thumbColor" value="414141" />
-    <option name="ScrollBar.Mac.thumbBorderColor" value="414141" />
-    <option name="ScrollBar.Mac.hoverTrackColor" value="1d1d1d" />
-    <option name="ScrollBar.Mac.hoverThumbColor" value="4e4e4e" />
-    <option name="ScrollBar.Mac.hoverThumbBorderColor" value="4e4e4e" />
-    
-    <option name="ScrollBar.Transparent.trackColor" value="1d1d1d" />
-    <option name="ScrollBar.Transparent.thumbColor" value="414141" />
-    <option name="ScrollBar.Transparent.thumbBorderColor" value="414141" />
-    <option name="ScrollBar.Transparent.hoverTrackColor" value="1d1d1d" />
-    <option name="ScrollBar.Transparent.hoverThumbColor" value="4e4e4e" />
-    <option name="ScrollBar.Transparent.hoverThumbBorderColor" value="4e4e4e" />
+
+    <option name="ScrollBar.Mac.trackColor" value="1d1d1d"/>
+    <option name="ScrollBar.Mac.thumbColor" value="414141"/>
+    <option name="ScrollBar.Mac.thumbBorderColor" value="414141"/>
+    <option name="ScrollBar.Mac.hoverTrackColor" value="1d1d1d"/>
+    <option name="ScrollBar.Mac.hoverThumbColor" value="4e4e4e"/>
+    <option name="ScrollBar.Mac.hoverThumbBorderColor" value="4e4e4e"/>
+
+    <option name="ScrollBar.Transparent.trackColor" value="1d1d1d"/>
+    <option name="ScrollBar.Transparent.thumbColor" value="414141"/>
+    <option name="ScrollBar.Transparent.thumbBorderColor" value="414141"/>
+    <option name="ScrollBar.Transparent.hoverTrackColor" value="1d1d1d"/>
+    <option name="ScrollBar.Transparent.hoverThumbColor" value="4e4e4e"/>
+    <option name="ScrollBar.Transparent.hoverThumbBorderColor" value="4e4e4e"/>
   </colors>
   <attributes>
     <option name="ANNOTATION_ATTRIBUTE_NAME_ATTRIBUTES">

--- a/resources/visual_studio_code_dark_plus.xml
+++ b/resources/visual_studio_code_dark_plus.xml
@@ -1,8 +1,8 @@
 <scheme name="Visual Studio Code Dark Plus" version="143" parent_scheme="Darcula">
   <metaInfo>
-    <property name="created">2020-02-05T15:57:56</property>
-    <property name="ide">GoLand</property>
-    <property name="ideVersion">2019.3.2.0.0</property>
+    <property name="created">2019-07-05T16:51:16</property>
+    <property name="ide">Idea</property>
+    <property name="ideVersion">2019.1.2.0.0</property>
     <property name="modified">2020-02-05T15:58:12</property>
     <property name="originalScheme">Visual Studio Code Dark Plus</property>
   </metaInfo>
@@ -11,21 +11,24 @@
     <option name="CARET_ROW_COLOR" value="262626" />
     <option name="GUTTER_BACKGROUND" value="1d1d1d" />
     <option name="INDENT_GUIDE" value="3b3b3b" />
-    <option name="LINE_NUMBERS_COLOR" value="848484" />
     <option name="RIGHT_MARGIN_COLOR" value="3b3b3b" />
     <option name="SELECTION_BACKGROUND" value="264e77" />
-    <option name="ScrollBar.Mac.hoverThumbBorderColor" value="4e4e4e" />
-    <option name="ScrollBar.Mac.hoverThumbColor" value="4e4e4e" />
-    <option name="ScrollBar.Mac.hoverTrackColor" value="1d1d1d" />
-    <option name="ScrollBar.Mac.thumbBorderColor" value="414141" />
-    <option name="ScrollBar.Mac.thumbColor" value="414141" />
+    <option name="LINE_NUMBERS_COLOR" value="848484" />
+    
     <option name="ScrollBar.Mac.trackColor" value="1d1d1d" />
-    <option name="ScrollBar.Transparent.hoverThumbBorderColor" value="4e4e4e" />
-    <option name="ScrollBar.Transparent.hoverThumbColor" value="4e4e4e" />
-    <option name="ScrollBar.Transparent.hoverTrackColor" value="1d1d1d" />
-    <option name="ScrollBar.Transparent.thumbBorderColor" value="414141" />
-    <option name="ScrollBar.Transparent.thumbColor" value="414141" />
+    <option name="ScrollBar.Mac.thumbColor" value="414141" />
+    <option name="ScrollBar.Mac.thumbBorderColor" value="414141" />
+    <option name="ScrollBar.Mac.hoverTrackColor" value="1d1d1d" />
+    <option name="ScrollBar.Mac.hoverThumbColor" value="4e4e4e" />
+    <option name="ScrollBar.Mac.hoverThumbBorderColor" value="4e4e4e" />
+    
     <option name="ScrollBar.Transparent.trackColor" value="1d1d1d" />
+    <option name="ScrollBar.Transparent.thumbColor" value="414141" />
+    <option name="ScrollBar.Transparent.thumbBorderColor" value="414141" />
+    <option name="ScrollBar.Transparent.hoverTrackColor" value="1d1d1d" />
+    <option name="ScrollBar.Transparent.hoverThumbColor" value="4e4e4e" />
+    <option name="ScrollBar.Transparent.hoverThumbBorderColor" value="4e4e4e" />
+    
     <option name="VISUAL_INDENT_GUIDE" value="3b3b3b" />
   </colors>
   <attributes>

--- a/resources/visual_studio_code_dark_plus.xml
+++ b/resources/visual_studio_code_dark_plus.xml
@@ -34,7 +34,7 @@
     <option name="ANNOTATION_ATTRIBUTE_NAME_ATTRIBUTES">
       <value />
     </option>
-    <option name="ANNOTATION_NAME_ATTRIBUTES" baseAttributes="" />
+    <option name="ANNOTATION_NAME_ATTRIBUTES" baseAttributes="DEFAULT_METADATA" />
     <option name="BAD_CHARACTER">
       <value>
         <option name="EFFECT_COLOR" value="f44747" />
@@ -51,6 +51,7 @@
         <option name="FOREGROUND" value="dcdcaa" />
       </value>
     </option>
+    <option name="BASH.HERE_DOC" baseAttributes="DEFAULT_STRING" />
     <option name="BASH.HERE_DOC_END">
       <value>
         <option name="FOREGROUND" value="c586c0" />
@@ -61,6 +62,7 @@
         <option name="FOREGROUND" value="c586c0" />
       </value>
     </option>
+    <option name="BASH.SHEBANG" baseAttributes="BASH.LINE_COMMENT" />
     <option name="BASH.VAR_DEF">
       <value>
         <option name="FOREGROUND" value="d3d3c8" />
@@ -159,7 +161,7 @@
     </option>
     <option name="DEFAULT_CONSTANT">
       <value>
-        <option name="FOREGROUND" value="569cd6" />
+        <option name="FOREGROUND" value="d3d3d3" />
       </value>
     </option>
     <option name="DEFAULT_DOC_COMMENT">
@@ -494,12 +496,13 @@
     <option name="INJECTED_LANGUAGE_FRAGMENT">
       <value />
     </option>
-    <option name="JAVA_KEYWORD" baseAttributes="" />
+    <option name="JAVA_KEYWORD" baseAttributes="DEFAULT_KEYWORD" />
     <option name="JS.PARAMETER">
       <value>
         <option name="FOREGROUND" value="9cdcfe" />
       </value>
     </option>
+    <option name="KOTLIN_ANNOTATION" baseAttributes="ANNOTATION_NAME_ATTRIBUTES" />
     <option name="KOTLIN_BACKING_FIELD_VARIABLE">
       <value />
     </option>
@@ -520,6 +523,8 @@
     <option name="KOTLIN_OBJECT">
       <value />
     </option>
+    <option name="KOTLIN_PACKAGE_FUNCTION_CALL" baseAttributes="DEFAULT_STATIC_METHOD" />
+    <option name="KOTLIN_TYPE_PARAMETER" baseAttributes="TYPE_PARAMETER_NAME_ATTRIBUTES" />
     <option name="MARKDOWN_AUTO_LINK">
       <value>
         <option name="EFFECT_COLOR" value="d4d4d4" />
@@ -639,6 +644,7 @@
     <option name="PHP_ALIAS_REFERENCE">
       <value />
     </option>
+    <option name="PHP_CONSTANT" baseAttributes="DEFAULT_CONSTANT" />
     <option name="PHP_EXEC_COMMAND_ID">
       <value>
         <option name="FOREGROUND" value="cd905b" />
@@ -659,10 +665,10 @@
         <option name="FOREGROUND" value="94dbfd" />
       </value>
     </option>
-    <option name="PROPERTIES.INVALID_STRING_ESCAPE" baseAttributes="" />
-    <option name="PROPERTIES.KEY" baseAttributes="" />
-    <option name="PROPERTIES.KEY_VALUE_SEPARATOR" baseAttributes="" />
-    <option name="PROPERTIES.VALID_STRING_ESCAPE" baseAttributes="" />
+    <option name="PROPERTIES.INVALID_STRING_ESCAPE" baseAttributes="DEFAULT_INVALID_STRING_ESCAPE" />
+    <option name="PROPERTIES.KEY" baseAttributes="DEFAULT_KEYWORD" />
+    <option name="PROPERTIES.KEY_VALUE_SEPARATOR" baseAttributes="DEFAULT_OPERATION_SIGN" />
+    <option name="PROPERTIES.VALID_STRING_ESCAPE" baseAttributes="DEFAULT_VALID_STRING_ESCAPE" />
     <option name="REGEXP.CHAR_CLASS">
       <value>
         <option name="FOREGROUND" value="d16969" />
@@ -702,7 +708,8 @@
     <option name="STATIC_METHOD_ATTRIBUTES">
       <value />
     </option>
-    <option name="Static method access" baseAttributes="" />
+    <option name="Static method access" baseAttributes="STATIC_METHOD_ATTRIBUTES" />
+    <option name="Static property reference ID" baseAttributes="STATIC_FINAL_FIELD_ATTRIBUTES" />
     <option name="TEXT">
       <value>
         <option name="FOREGROUND" value="d4d4d4" />
@@ -755,7 +762,7 @@
     <option name="XPATH.BRACKET">
       <value />
     </option>
-    <option name="XPATH.KEYWORD" baseAttributes="" />
-    <option name="XPATH.XPATH_VARIABLE" baseAttributes="" />
+    <option name="XPATH.KEYWORD" baseAttributes="DEFAULT_KEYWORD" />
+    <option name="XPATH.XPATH_VARIABLE" baseAttributes="DEFAULT_LOCAL_VARIABLE" />
   </attributes>
 </scheme>


### PR DESCRIPTION
This adds VS Code Dark+ styling to GoLang.

Known issue is that "func" is purple with the rest of the language keywords, instead of blue.