### PR TITLE
Fix #19 python colors to more closely match VS Code Dark+

### DIFF
--- a/resources/visual_studio_code_dark_plus.xml
+++ b/resources/visual_studio_code_dark_plus.xml
@@ -713,12 +713,6 @@
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
-    <option name="REGEXP.CHAR_CLASS">
-      <value>
-        <option name="FOREGROUND" value="d16969" />
-        <option name="FONT_TYPE" value="1" />
-      </value>
-    </option>
     <option name="SEARCH_RESULT_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="dcdcaa" />

--- a/resources/visual_studio_code_dark_plus.xml
+++ b/resources/visual_studio_code_dark_plus.xml
@@ -674,6 +674,45 @@
     <option name="PROPERTIES.KEY" baseAttributes="DEFAULT_KEYWORD" />
     <option name="PROPERTIES.KEY_VALUE_SEPARATOR" baseAttributes="DEFAULT_OPERATION_SIGN" />
     <option name="PROPERTIES.VALID_STRING_ESCAPE" baseAttributes="DEFAULT_VALID_STRING_ESCAPE" />
+     <option name="PY.BUILTIN_NAME">
+      <value>
+        <option name="FOREGROUND" value="39c8b0" />
+      </value>
+    </option>
+    <option name="PY.DECORATOR">
+      <value>
+        <option name="FOREGROUND" value="39c8b0" />
+        <option name="EFFECT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="PY.KEYWORD" baseAttributes="DEFAULT_KEYWORD" />
+    <option name="PY.KEYWORD_ARGUMENT">
+      <value>
+        <option name="FOREGROUND" value="94dbfd" />
+      </value>
+    </option>
+    <option name="PY.PREDEFINED_DEFINITION">
+      <value>
+        <option name="FOREGROUND" value="dcdcaa" />
+      </value>
+    </option>
+    <option name="PY.PREDEFINED_USAGE">
+      <value>
+        <option name="FOREGROUND" value="dcdcaa" />
+      </value>
+    </option>
+    <option name="PY.SELF_PARAMETER">
+      <value>
+        <option name="FOREGROUND" value="569cd5" />
+      </value>
+    </option>
+    <option name="PY.STRING.B" baseAttributes="DEFAULT_STRING" />
+    <option name="REGEXP.CHAR_CLASS">
+      <value>
+        <option name="FOREGROUND" value="d16969" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
     <option name="REGEXP.CHAR_CLASS">
       <value>
         <option name="FOREGROUND" value="d16969" />


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔
| Fixed issues  | #19 

Before:
![Screen Shot 2020-08-24 at 1 59 24 PM](https://user-images.githubusercontent.com/1075421/91079472-138c8f00-e612-11ea-8e98-e7e4f685102d.png)

After:
![Screen Shot 2020-08-24 at 1 57 22 PM](https://user-images.githubusercontent.com/1075421/91079290-e0e29680-e611-11ea-9f52-e9d69e211edf.png)