### PR TITLE
Adjust JavaScript colors

### DIFF
--- a/resources/visual_studio_code_dark_plus.xml
+++ b/resources/visual_studio_code_dark_plus.xml
@@ -783,13 +783,6 @@
         <option name="FOREGROUND" value="39c8b0" />
       </value>
     </option>
-    <option name="WARNING_ATTRIBUTES">
-      <value>
-        <option name="EFFECT_COLOR" value="be9117" />
-        <option name="ERROR_STRIPE_COLOR" value="be9117" />
-        <option name="EFFECT_TYPE" value="2" />
-      </value>
-    </option>
     <option name="XML_ATTRIBUTE_NAME">
       <value>
         <option name="FOREGROUND" value="9cdcfe" />

--- a/resources/visual_studio_code_dark_plus.xml
+++ b/resources/visual_studio_code_dark_plus.xml
@@ -161,7 +161,7 @@
     </option>
     <option name="DEFAULT_CONSTANT">
       <value>
-        <option name="FOREGROUND" value="dcdcaa" />
+        <option name="FOREGROUND" value="d3d3d3" />
       </value>
     </option>
     <option name="DEFAULT_DOC_COMMENT">

--- a/resources/visual_studio_code_dark_plus.xml
+++ b/resources/visual_studio_code_dark_plus.xml
@@ -3,7 +3,7 @@
     <property name="created">2019-07-05T16:51:16</property>
     <property name="ide">Idea</property>
     <property name="ideVersion">2019.1.2.0.0</property>
-    <property name="modified">2020-02-05T15:58:12</property>
+    <property name="modified">2021-03-01T17:55:17</property>
     <property name="originalScheme">Visual Studio Code Dark Plus</property>
   </metaInfo>
   <colors>
@@ -161,7 +161,7 @@
     </option>
     <option name="DEFAULT_CONSTANT">
       <value>
-        <option name="FOREGROUND" value="d3d3d3" />
+        <option name="FOREGROUND" value="dcdcaa" />
       </value>
     </option>
     <option name="DEFAULT_DOC_COMMENT">
@@ -497,6 +497,18 @@
       <value />
     </option>
     <option name="JAVA_KEYWORD" baseAttributes="DEFAULT_KEYWORD" />
+    <option name="JS.CLASS">
+      <value>
+        <option name="FOREGROUND" value="39c8b0" />
+      </value>
+    </option>
+    <option name="JS.GLOBAL_FUNCTION" baseAttributes="DEFAULT_FUNCTION_DECLARATION" />
+    <option name="JS.GLOBAL_VARIABLE">
+      <value>
+        <option name="FOREGROUND" value="39c8b0" />
+      </value>
+    </option>
+    <option name="JS.INSTANCE_MEMBER_FUNCTION" baseAttributes="DEFAULT_INSTANCE_METHOD" />
     <option name="JS.PARAMETER">
       <value>
         <option name="FOREGROUND" value="9cdcfe" />
@@ -769,6 +781,13 @@
     <option name="TYPE_PARAMETER_NAME_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="39c8b0" />
+      </value>
+    </option>
+    <option name="WARNING_ATTRIBUTES">
+      <value>
+        <option name="EFFECT_COLOR" value="be9117" />
+        <option name="ERROR_STRIPE_COLOR" value="be9117" />
+        <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="XML_ATTRIBUTE_NAME">


### PR DESCRIPTION
Now it looks more like in VSCode. 

P.S. IDEA still can't highlight keywords like `if`, `import`, `export`, etc. Not only in JS, but in other languages too. There is an [issue](https://youtrack.jetbrains.com/issue/IDEABKL-5473) about it.

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔
| New feature?  | ❌
| Fixed issues  | #28 

PhpStorm before | VSCode | PhpStorm after
--------------|--------------|---------------
<img width="300" alt="Screen Shot 2021-03-01 at 17 27 55" src="https://user-images.githubusercontent.com/9428948/109470693-82640c80-7abb-11eb-80ed-b178f86ea950.png"> | <img width="300" alt="Screen Shot 2021-03-01 at 17 29 03" src="https://user-images.githubusercontent.com/9428948/109470733-8db73800-7abb-11eb-83cc-f28dc198ea1b.png"> | <img width="300" alt="Screen Shot 2021-03-01 at 17 34 56" src="https://user-images.githubusercontent.com/9428948/109470784-9c055400-7abb-11eb-99e7-51cdd547073b.png">



