### PR TITLE
Make warnings look more like a VSCode ones

### DIFF
--- a/resources/visual_studio_code_dark_plus.xml
+++ b/resources/visual_studio_code_dark_plus.xml
@@ -783,6 +783,13 @@
         <option name="FOREGROUND" value="39c8b0" />
       </value>
     </option>
+    <option name="WARNING_ATTRIBUTES">
+      <value>
+        <option name="EFFECT_COLOR" value="be9117" />
+        <option name="ERROR_STRIPE_COLOR" value="be9117" />
+        <option name="EFFECT_TYPE" value="2" />
+      </value>
+    </option>
     <option name="XML_ATTRIBUTE_NAME">
       <value>
         <option name="FOREGROUND" value="9cdcfe" />


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔

PhpStorm before | VSCode | PhpStorm after
------ | ------ | -----
<img width="200" alt="Screen Shot 2021-03-03 at 20 16 09" src="https://user-images.githubusercontent.com/9428948/109791791-9300b800-7c5e-11eb-9403-22a98869273f.png"> | <img width="200" alt="Screen Shot 2021-03-03 at 20 18 39" src="https://user-images.githubusercontent.com/9428948/109791832-9c8a2000-7c5e-11eb-8f8a-05c2e28a288b.png"> | <img width="200" alt="Screen Shot 2021-03-03 at 20 16 53" src="https://user-images.githubusercontent.com/9428948/109791852-a3189780-7c5e-11eb-88c0-4b4620064866.png">



