### PR TITLE
Adjust JSDoc colors

### DIFF
--- a/resources/visual_studio_code_dark_plus.xml
+++ b/resources/visual_studio_code_dark_plus.xml
@@ -175,6 +175,16 @@
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
+    <option name="DEFAULT_DOC_COMMENT_TAG_VALUE">
+      <value>
+        <option name="FOREGROUND" value="9cdcfe" />
+      </value>
+    </option>
+    <option name="DEFAULT_DOC_MARKUP">
+      <value>
+        <option name="FOREGROUND" value="569cd5" />
+      </value>
+    </option>
     <option name="DEFAULT_FUNCTION_CALL">
       <value>
         <option name="FOREGROUND" value="dbdbaa" />
@@ -498,6 +508,11 @@
     </option>
     <option name="JAVA_KEYWORD" baseAttributes="DEFAULT_KEYWORD" />
     <option name="JS.CLASS">
+      <value>
+        <option name="FOREGROUND" value="39c8b0" />
+      </value>
+    </option>
+    <option name="JS.DOC_TYPE">
       <value>
         <option name="FOREGROUND" value="39c8b0" />
       </value>


### PR DESCRIPTION
I adjusted some `DEFAULT_DOC` colors to match VSCode ones (probably was legacy from Darcula). So JSDoc tags can inherit correct ones now.

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔
| New feature?  | ✔

PhpStorm before | VSCode | PhpStorm after
----- | ----- | -----
<img width="200" alt="Screen Shot 2021-03-03 at 22 49 19" src="https://user-images.githubusercontent.com/9428948/109810181-eed63b80-7c74-11eb-8d76-104951265969.png"> | <img width="200" alt="Screen Shot 2021-03-03 at 22 49 48" src="https://user-images.githubusercontent.com/9428948/109810258-0ad9dd00-7c75-11eb-8072-a4cf8aaa1701.png"> | <img width="200" alt="Screen Shot 2021-03-03 at 22 53 37" src="https://user-images.githubusercontent.com/9428948/109810313-1e854380-7c75-11eb-902f-e7976f0faec9.png">

Default doc adjustments:

Params before | Params after | Markup tags before | Markup tags after (matched with xml/html colors)
----- | ----- | ----- | -----
<img width="200" alt="Screen Shot 2021-03-03 at 22 50 34" src="https://user-images.githubusercontent.com/9428948/109810630-7de35380-7c75-11eb-8f48-31598c4b6f6a.png"> | <img width="200" alt="Screen Shot 2021-03-03 at 22 53 16" src="https://user-images.githubusercontent.com/9428948/109810653-86d42500-7c75-11eb-89c3-06915b7eb9d8.png"> | <img width="200" alt="Screen Shot 2021-03-03 at 23 11 51" src="https://user-images.githubusercontent.com/9428948/109810921-e9c5bc00-7c75-11eb-933d-bf75c28dfbcb.png"> | <img width="200" alt="Screen Shot 2021-03-03 at 22 55 33" src="https://user-images.githubusercontent.com/9428948/109810697-9489aa80-7c75-11eb-9a22-4021a906430c.png"> 







