### PR TITLE
Add code highlight under caret on scroll bar

### DIFF
--- a/resources/visual_studio_code_dark_plus.xml
+++ b/resources/visual_studio_code_dark_plus.xml
@@ -494,6 +494,7 @@
     <option name="IDENTIFIER_UNDER_CARET_ATTRIBUTES">
       <value>
         <option name="BACKGROUND" value="33393f" />
+        <option name="ERROR_STRIPE_COLOR" value="036b13" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>

--- a/resources/visual_studio_code_dark_plus.xml
+++ b/resources/visual_studio_code_dark_plus.xml
@@ -494,7 +494,7 @@
     <option name="IDENTIFIER_UNDER_CARET_ATTRIBUTES">
       <value>
         <option name="BACKGROUND" value="33393f" />
-        <option name="ERROR_STRIPE_COLOR" value="036b13" />
+        <option name="ERROR_STRIPE_COLOR" value="A0A0A0" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>


### PR DESCRIPTION
<!-- If the changes are about visible parts of the UI or code highlighting, please provide before/after screenshots to
make review faster. Thanks! -->

| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔
| Fixed issues  | Add code highlight under caret on the scroll bar same as in IntelliJ IDEA Darcula theme

In the IntelliJ IDEA Darcula theme, this highlight is existed by default, after installing the Visual Studio Code Dark Plus theme this feature is missing and may confuse many users that used it for code navigation (many times another team members were confused during work in pair and missing code highlight)

Before screenshot:
<img width="686" alt="highlight_before" src="https://user-images.githubusercontent.com/8240025/111044958-408c7c00-8454-11eb-8a95-eba295327388.png">

After screenshot:
<img width="686" alt="highlight_after" src="https://user-images.githubusercontent.com/8240025/111044969-539f4c00-8454-11eb-83e9-7517e2258942.png">

What setting was changed:
![selected_code_highlighted_on_scrollbar](https://user-images.githubusercontent.com/8240025/111045000-6d409380-8454-11eb-9281-736c5a6cdaba.png)

Same feature in VS Code (not used their color because of not best UX in my opinion, but if required can update according to an original theme):
<img width="586" alt="vs_code_highlight_under_caret" src="https://user-images.githubusercontent.com/8240025/111045066-c9a3b300-8454-11eb-93ce-3245d8b48bf4.png">

