### PR TITLE
set console background

### DIFF
--- a/resources/visual_studio_code_dark_plus.xml
+++ b/resources/visual_studio_code_dark_plus.xml
@@ -9,6 +9,7 @@
   <colors>
     <option name="CARET_COLOR" value="adaeac" />
     <option name="CARET_ROW_COLOR" value="262626" />
+    <option name="CONSOLE_BACKGROUND_KEY" value="1d1d1d" />
     <option name="GUTTER_BACKGROUND" value="1d1d1d" />
     <option name="INDENT_GUIDE" value="3b3b3b" />
     <option name="RIGHT_MARGIN_COLOR" value="3b3b3b" />


### PR DESCRIPTION
This sets the Console Background color which was previously unset and inherited from Darcula theme

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔
| New feature?  | ❌
| Fixed issues  | #51 
